### PR TITLE
Fix for possible race condition in parallel runs 

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -90,17 +90,12 @@ os.32or64bit <- function ()
 # Checks that the executable can be run by the user
 check.executable <- function() {
  if (os.type("linux")) {
-   system(paste0("ls -l ", a4a.dir(), "/a4a > syslog.txt"))
-   syslog <- readLines("syslog.txt")
-   unlink("syslog.txt")
-   
-   is.x <- grepl("x", substring(syslog, 1,10))
- 
-   if (!is.x) {
+   is.x <- file.access(paste0(a4a.dir(), "/a4a"), 1)[[1]]
+
+   if (is.x != 0) {
      message(paste0(
        "Something has gone wrong!\n",
        "the a4a executable has the wrong permissions:\n\t",
-          substring(syslog, 1,10), 
      "\nPlease change permissions (in a terminal) to a+x using\n",
        "\tchmod a+x ", a4a.dir(), "/a4a\n",
        "if you installed under sudo you will have to run:\n",


### PR DESCRIPTION
This introduces simpler execute permission check in check.executable(). 

Because writing-and-then-deleting the transient syslog.txt file can possibly trigger race condition during parallel R sessions.

We recently faced this error when running FLa4a in parallel (using forceach - %dopar%):

```R
Error in e$fun(obj, substitute(ex), parent.frame(), e$data) :
  worker initialization failed: package or namespace load failed for ‘FLa4a’:
 .onAttach failed in attachNamespace() for 'FLa4a', details:
  call: file(con, "r")
  error: cannot open the connection
Calls: source ... withVisible -> eval -> eval -> %dopar% -> <Anonymous>
In addition: Warning messages:
1: replacing previous import ‘ggplot2::%+%’ by ‘FLCore::%+%’ when loading ‘ggplo
2: replacing previous import ‘reshape::expand’ by ‘FLCore::expand’ when loading
3: multiple methods tables found for ‘fwdWindow’
4: multiple methods tables found for ‘refpts’
5: multiple methods tables found for ‘msy’
Execution halted
```
This commit seems to have fixed it.